### PR TITLE
ENG-796 get users fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-admin-client</artifactId>
-            <version>7.0.1</version>
+            <version>11.0.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/entando/entando/keycloak/services/KeycloakUserManager.java
+++ b/src/main/java/org/entando/entando/keycloak/services/KeycloakUserManager.java
@@ -4,7 +4,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 
 import com.agiletec.aps.system.exception.ApsSystemException;
-import com.agiletec.aps.system.services.authorization.AuthorizationManager;
 import com.agiletec.aps.system.services.authorization.IAuthorizationManager;
 import com.agiletec.aps.system.services.user.IUserManager;
 import com.agiletec.aps.system.services.user.User;
@@ -158,7 +157,7 @@ public class KeycloakUserManager implements IUserManager {
     }
 
     private Optional<UserRepresentation> getUserRepresentation(final String username) {
-        return keycloakService.listUsers(username).stream().findFirst();
+        return keycloakService.listUsers(username).stream().filter(f->f.getUsername().equals(username)).findFirst();
     }
 
 }

--- a/src/test/java/org/entando/entando/keycloak/services/UserManagerIT.java
+++ b/src/test/java/org/entando/entando/keycloak/services/UserManagerIT.java
@@ -1,9 +1,14 @@
 package org.entando.entando.keycloak.services;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+
 import com.agiletec.aps.system.exception.ApsSystemException;
 import com.agiletec.aps.system.services.authorization.IAuthorizationManager;
 import com.agiletec.aps.system.services.user.User;
 import com.agiletec.aps.system.services.user.UserDetails;
+import java.util.List;
 import org.entando.entando.keycloak.KeycloakTestConfiguration;
 import org.entando.entando.keycloak.services.oidc.OpenIDConnectService;
 import org.entando.entando.web.user.model.UserPasswordRequest;
@@ -12,15 +17,13 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-
 public class UserManagerIT {
 
     private static final String USERNAME = "marine";
+
+    private static final String USER_1 ="user1";
+    private static final String USER_2 ="user2";
+    private static final String USER_3 ="user1user2";
 
     @Mock private IAuthorizationManager authorizationManager;
 
@@ -29,6 +32,7 @@ public class UserManagerIT {
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
+
         final KeycloakConfiguration configuration = KeycloakTestConfiguration.getConfiguration();
         final OpenIDConnectService oidcService = new OpenIDConnectService(configuration);
         final KeycloakService keycloakService = new KeycloakService(configuration, oidcService);
@@ -94,6 +98,32 @@ public class UserManagerIT {
         assertThat(usernames).hasSize(3).contains(USERNAME, "cop", "doomguy");
         assertThat(searchUsernames).hasSize(1).contains(USERNAME);
         assertThat(noUsernames).isEmpty();
+    }
+
+    @Test
+    public void testConcatStringUsernames() {
+        userManager.addUser(activeUser(USER_1));
+        userManager.addUser(activeUser(USER_2));
+        userManager.addUser(activeUser(USER_3));
+
+        final List<String> usernames = userManager.getUsernames();
+        final List<String> searchUsernamesContainsUser = userManager.searchUsernames(USER_1);
+        final List<String> searchUsernamesContainsTest = userManager.searchUsernames(USER_2);
+        final List<String> searchUsernameUserTest = userManager.searchUsernames(USER_3);
+        final List<String> noUsernames = userManager.searchUsernames("1010");
+
+        assertThat(usernames).hasSize(3).contains( USER_1, USER_2, USER_3);
+        assertThat(searchUsernamesContainsUser).hasSize(2).contains( USER_1, USER_3);
+        assertThat(searchUsernamesContainsTest).hasSize(2).contains( USER_2, USER_3);
+        assertThat(searchUsernameUserTest).hasSize(1).contains( USER_3 );
+        assertThat(noUsernames).isEmpty();
+
+        final UserDetails user1 = userManager.getUser(USER_1);
+        assertThat(user1).hasFieldOrPropertyWithValue("username", USER_1);
+        final UserDetails user2 = userManager.getUser(USER_2);
+        assertThat(user2).hasFieldOrPropertyWithValue("username", USER_2);
+        final UserDetails user3 = userManager.getUser(USER_3);
+        assertThat(user3).hasFieldOrPropertyWithValue("username", USER_3);
     }
 
     @Test


### PR DESCRIPTION
Hi @w-caffiero-entando @ampie @BrenoQVDS @Kerruba ,
This PR fixes an issue when creating users with usernames combination of other usernames.
I also updated the keycloak-admin-client (scope test) version because the integration tests didn't works with the latest version of keycloak (downloaded and run using dockercompose as suggested in the readme).

Could you please check this PR?
Thanks.